### PR TITLE
Correct selectedtheme

### DIFF
--- a/Avalonia.ExtendedToolkit/ThemeManager/ThemeManager.cs
+++ b/Avalonia.ExtendedToolkit/ThemeManager/ThemeManager.cs
@@ -109,7 +109,15 @@ namespace Avalonia.ExtendedToolkit
         /// </summary>
         public Theme SelectedTheme
         {
-            get => _selectedTheme;
+            get
+            {
+                if(_selectedTheme == null)
+                {
+                    _selectedTheme = Themes.FirstOrDefault();
+                }
+
+                return _selectedTheme;
+            }
             set
             {
                 this.RaiseAndSetIfChanged(ref _selectedTheme, value);
@@ -223,7 +231,7 @@ namespace Avalonia.ExtendedToolkit
             window.Opened += (o, e) =>
               {
 
-                  if(SelectedTheme==null)
+                  if (SelectedTheme == null)
                   {
                       SelectedTheme = Themes.FirstOrDefault();
                   }
@@ -338,7 +346,7 @@ namespace Avalonia.ExtendedToolkit
             var item = styles.GetThemeStyle();
 
             int index = styles.GetThemeStyleIndex(item);
-            if(index==-1)
+            if (index == -1)
             {
                 styles.Add(theme.ThemeStyle);
             }


### PR DESCRIPTION
## What does the pull request do?
Fix that a nullreference exception occured if the selected theme is checked in i.e. OnTemplateApplied


## What is the current behavior?
The Application crashed when using the Hamburger Menu, because no theme was selected on template applied

## Fix ##
just set the first available theme in the getter if the selected theme is null.



